### PR TITLE
Fix bug: merge PR 23 : https://github.com/microsoft/ltp-sglang/pull/23

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -87,6 +87,9 @@ global_server_args_dict = {
     "speculative_accept_threshold_single": ServerArgs.speculative_accept_threshold_single,
     "torchao_config": ServerArgs.torchao_config,
     "triton_attention_reduce_in_fp32": ServerArgs.triton_attention_reduce_in_fp32,
+    "enable_benchmark": ServerArgs.enable_benchmark,
+    "benchmark_num_warmup": ServerArgs.benchmark_num_warmup,
+    "benchmark_num_iters": ServerArgs.benchmark_num_iters,
 }
 
 logger = logging.getLogger(__name__)

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -43,6 +43,9 @@ from sglang.srt.utils import MultiprocessingSerializer, broadcast_pyobj, set_ran
 
 logger = logging.getLogger(__name__)
 
+WARMUP_STEPS = 50
+RUN_STEPS = 50
+
 
 class TpModelWorker:
     """A tensor parallel model worker."""
@@ -180,6 +183,38 @@ class TpModelWorker:
             self.model_runner.token_to_kv_pool_allocator,
         )
 
+    def run_batch_generation_benchmark(
+        self,
+        forward_batch: ForwardBatch,
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
+    ) -> Tuple[LogitsProcessorOutput, bool]:
+        warmup_steps = global_server_args_dict.get("benchmark_num_warmup", WARMUP_STEPS)
+        run_steps = global_server_args_dict.get("benchmark_num_iters", RUN_STEPS)
+
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+
+        for i in range(warmup_steps + run_steps):
+            if i == warmup_steps:
+                start.record()
+            logits_output, can_run_cuda_graph = self.model_runner.forward(
+                forward_batch, pp_proxy_tensors=pp_proxy_tensors
+            )
+        end.record()
+        torch.cuda.synchronize()
+
+        phase = "Prefill" if forward_batch.forward_mode == 1 else "Decode"
+        avg_latency = start.elapsed_time(end) / max(1, run_steps)
+
+        logger.info(
+            f"Latency Benchmark Device {torch.cuda.current_device()} "
+            f"Phase: {phase}, Batch Size: {forward_batch.batch_size}, "
+            f"Sequence Length: {forward_batch.seq_lens[0]}, "
+            f"Average Latency: {avg_latency:.4f} ms"
+        )
+
+        return logits_output, can_run_cuda_graph
+
     def forward_batch_generation(
         self,
         model_worker_batch: ModelWorkerBatch,
@@ -199,9 +234,16 @@ class TpModelWorker:
             )
 
         if self.pp_group.is_last_rank:
-            logits_output, can_run_cuda_graph = self.model_runner.forward(
-                forward_batch, pp_proxy_tensors=pp_proxy_tensors
-            )
+            if global_server_args_dict.get("enable_benchmark", False):
+                logits_output, can_run_cuda_graph = self.run_batch_generation_benchmark(
+                    forward_batch,
+                    pp_proxy_tensors=pp_proxy_tensors,
+                )
+            else:
+                logits_output, can_run_cuda_graph = self.model_runner.forward(
+                    forward_batch,
+                    pp_proxy_tensors=pp_proxy_tensors,
+                )
             if launch_done is not None:
                 launch_done.set()
 
@@ -214,10 +256,18 @@ class TpModelWorker:
 
             return logits_output, next_token_ids, can_run_cuda_graph
         else:
-            pp_proxy_tensors, can_run_cuda_graph = self.model_runner.forward(
-                forward_batch,
-                pp_proxy_tensors=pp_proxy_tensors,
-            )
+            if global_server_args_dict.get("enable_benchmark", False):
+                pp_proxy_tensors, can_run_cuda_graph = (
+                    self.run_batch_generation_benchmark(
+                        forward_batch,
+                        pp_proxy_tensors=pp_proxy_tensors,
+                    )
+                )
+            else:
+                pp_proxy_tensors, can_run_cuda_graph = self.model_runner.forward(
+                    forward_batch,
+                    pp_proxy_tensors=pp_proxy_tensors,
+                )
             return pp_proxy_tensors.tensors, None, can_run_cuda_graph
 
     def forward_batch_embedding(self, model_worker_batch: ModelWorkerBatch):

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -203,6 +203,11 @@ class ServerArgs:
     disaggregation_ib_device: Optional[str] = None
     pdlb_url: Optional[str] = None
 
+    # For warmup and benchmark
+    enable_benchmark: bool = False
+    benchmark_num_warmup: int = 50
+    benchmark_num_iters: int = 50
+
     def __post_init__(self):
         # Expert parallelism
         if self.enable_ep_moe:
@@ -1302,6 +1307,24 @@ class ServerArgs:
             choices=["sdpa", "fa3", "triton_attn"],
             default=ServerArgs.mm_attention_backend,
             help="Set multimodal attention backend.",
+        )
+
+        parser.add_argument(
+            "--enable-benchmark",
+            action="store_true",
+            help="Enable benchmark mode, which will run multiple times of the same input to obtain stable results.",
+        )
+        parser.add_argument(
+            "--benchmark-num-warmup",
+            type=int,
+            default=ServerArgs.benchmark_num_warmup,
+            help="Number of warmup iterations for benchmarking.",
+        )
+        parser.add_argument(
+            "--benchmark-num-iters",
+            type=int,
+            default=ServerArgs.benchmark_num_iters,
+            help="Number of iterations for benchmarking.",
         )
 
     @classmethod


### PR DESCRIPTION
The original [PR23 ](https://github.com/microsoft/ltp-sglang/pull/23) did not merge into main branch. 
Move it into release/1.0 branch for release

<!-- Thank you for your contribution! We appreciate it. The following guidelines will help improve your pull request and facilitate feedback. If anything is unclear, don't hesitate to submit your pull request and ask the maintainers for assistance. -->
This pull request introduces a benchmarking feature for batch generation in the tensor parallel model worker, along with related configuration changes. The key updates include adding a new benchmarking mode, modifying batch generation logic to support benchmarking, and updating command-line arguments to enable this feature.

### Benchmarking Feature:

* Added a new `enable_benchmark` configuration option to the global server arguments and the `ServerArgs` class, allowing users to enable benchmarking mode. This mode runs multiple iterations of the same input to measure stable latency results. (`python/sglang/srt/managers/schedule_batch.py`, `python/sglang/srt/server_args.py`: [[1]](diffhunk://#diff-b4937569fc71f6ad215181b633b2f89c7183a2b4ac39e41fc22635599a9be7deR105) [[2]](diffhunk://#diff-700b5118b493d60d7b5994857f5f1e6a7e842ad702392b8ab199945764dfc8edR250-R252) [[3]](diffhunk://#diff-700b5118b493d60d7b5994857f5f1e6a7e842ad702392b8ab199945764dfc8edR1686-R1690)

* Introduced constants `WARMUP_STEPS` and `RUN_STEPS` in `tp_worker.py` to define the number of warmup and benchmark iterations. (`python/sglang/srt/managers/tp_worker.py`: [python/sglang/srt/managers/tp_worker.pyR49-R50](diffhunk://#diff-6a2b322b8a289387583105f11095a3a62577a72a456d47eb235ee8eb20196bb2R49-R50))

### Batch Generation Logic:

* Added a new method `run_batch_generation` in `TpModelWorker` to handle batch generation with optional benchmarking. This method logs latency measurements when benchmarking is enabled. (`python/sglang/srt/managers/tp_worker.py`: [python/sglang/srt/managers/tp_worker.pyR197-R224](diffhunk://#diff-6a2b322b8a289387583105f11095a3a62577a72a456d47eb235ee8eb20196bb2R197-R224))

* Updated the `forward_batch_generation` method to delegate batch generation to the new `run_batch_generation` method, ensuring consistent handling of both normal and benchmarked runs. (`python/sglang/srt/managers/tp_worker.py`: [[1]](diffhunk://#diff-6a2b322b8a289387583105f11095a3a62577a72a456d47eb235ee8eb20196bb2L214-R249) [[2]](diffhunk://#diff-6a2b322b8a289387583105f11095a3a62577a72a456d47eb235ee8eb20196bb2L229-R267)