### PR TITLE
Fix Bug: Fix memcouter init issue

### DIFF
--- a/benchmark/sigma_v2/python/tools/main.py
+++ b/benchmark/sigma_v2/python/tools/main.py
@@ -53,7 +53,12 @@ def main():
         models_info[config.name] = {}
         for counter_name in counter_names:
             try:
-                counter = CounterRegistry.get_counter(counter_name)
+                if "mem" in counter_name:
+                    counter = CounterRegistry.get_counter(
+                        counter_name, precision_bytes=config.precision_bytes
+                    )
+                else:
+                    counter = CounterRegistry.get_counter(counter_name)
                 result = counter.get_model_results(seq_len, config)
                 models_info[config.name][counter.metric_name] = result
             except (ValueError, IndexError) as e:

--- a/benchmark/sigma_v2/python/tools/mem_counter.py
+++ b/benchmark/sigma_v2/python/tools/mem_counter.py
@@ -16,8 +16,8 @@ class MemCounter(BaseCounter):
     """Base counter for memory access bytes calculations. Support MHA, GQA, MLA with LoRA"""
 
     def __init__(self, **kwargs):
-        self.model_precision_bytes = kwargs.get("precision_bytes")
-        self.quantization_block_size = kwargs.get("quantization_block_size", 128)
+        super().__init__()
+        self.model_precision_bytes = kwargs.get("precision_bytes", 2)
 
     def tensor_size(
         self,

--- a/benchmark/sigma_v2/python/tools/model_config.py
+++ b/benchmark/sigma_v2/python/tools/model_config.py
@@ -66,6 +66,7 @@ class ModelConfig:
         if "quantization_config" in config_dict:
             quant_method = config_dict["quantization_config"].get("quant_method", None)
             result["precision"] = quant_method if quant_method else "bf16"
+            result["precision_bytes"] = PRECISION_TO_BYTES.get(result["precision"], 2)
 
         if missing_required:
             raise ValueError(


### PR DESCRIPTION
This pull request improves how memory counters handle precision in the benchmarking tools. The main change is to ensure that memory-related counters receive the correct `precision_bytes` value, defaulting to 2 when not specified, which leads to more accurate memory usage calculations.

**Precision handling improvements:**

* Updated `main.py` to pass `precision_bytes` to counters whose names include `"mem"`, ensuring memory counters use the correct precision for calculations.
* Modified `MemCounter` initialization in `mem_counter.py` to default `precision_bytes` to 2 if not provided, and removed the unused `quantization_block_size` parameter.
* Enhanced `from_dict` in `model_config.py` to set `precision_bytes` based on the model's precision, defaulting to 2 if not found in the mapping.