### PR TITLE
Build: Update the base docker image to sglang v0.4.10.post2

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -28,11 +28,11 @@ jobs:
       matrix:
         include:
         - name: cuda
-          base-image: 'lmsysorg/sglang:v0.4.6.post4-cu124'
+          base-image: 'lmsysorg/sglang:v0.4.10.post2-cu126'
           platforms: linux/amd64
           runtime: cuda
         - name: rocm
-          base-image: 'rocm/sgl-dev:20250518-srt'
+          base-image: 'lmsysorg/sglang:v0.4.10.post2-rocm630-mi30x-srt'
           platforms: linux/amd64
           runtime: rocm
     steps:

--- a/scripts/ltp_scripts/build_image.sh
+++ b/scripts/ltp_scripts/build_image.sh
@@ -15,7 +15,7 @@ project_dir="$script_dir/../.."
 
 # Build the CUDA-based Docker image
 docker build \
-    --build-arg BASE_IMAGE=lmsysorg/sglang:v0.4.6.post4-cu124 \
+    --build-arg BASE_IMAGE=lmsysorg/sglang:v0.4.10.post2-cu126 \
     --build-arg SGLANG_SRC=$project_dir \
     -t sglang-inference-cuda:$tag \
     -f ./dev.cuda.dockerfile \
@@ -23,7 +23,7 @@ docker build \
 
 # Build the ROCm-based Docker image
 docker build \
-    --build-arg BASE_IMAGE=rocm/sgl-dev:20250518-srt \
+    --build-arg BASE_IMAGE=lmsysorg/sglang:v0.4.10.post2-rocm630-mi30x-srt \
     --build-arg SGLANG_SRC=$project_dir \
     -t sglang-inference-rocm:$tag \
     -f ./dev.rocm.dockerfile \


### PR DESCRIPTION

## Motivation

This pull request updates the base images used for building both CUDA and ROCm Docker images to newer versions. The changes ensure that the project uses the latest supported images for improved compatibility and performance.

## Modifications


**Docker image base updates:**

* Updated the CUDA base image from `lmsysorg/sglang:v0.4.6.post4-cu124` to `lmsysorg/sglang:v0.4.10.post2-cu126` in both the GitHub Actions workflow (`.github/workflows/build-docker-image.yml`) and the build script (`scripts/ltp_scripts/build_image.sh`). [[1]](diffhunk://#diff-5b40193e09025fd041de92d38c976d0b469e3ee85bef45a71d05d8b5078b1ee8L31-R35) [[2]](diffhunk://#diff-8e9458221f3d1275ff9d383c1c973f0148f7620ff60d332c1a279ae5ac485103L18-R26)
* Updated the ROCm base image from `rocm/sgl-dev:20250518-srt` to `lmsysorg/sglang:v0.4.10.post2-rocm630-mi30x-srt` in both the GitHub Actions workflow and the build script. [[1]](diffhunk://#diff-5b40193e09025fd041de92d38c976d0b469e3ee85bef45a71d05d8b5078b1ee8L31-R35) [[2]](diffhunk://#diff-8e9458221f3d1275ff9d383c1c973f0148f7620ff60d332c1a279ae5ac485103L18-R26)

