### PR TITLE
Bug Fix - Data corruption bug in DP communication

### DIFF
--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -541,6 +541,8 @@ class CommunicateSummableTensorPairFn:
             forward_batch.gathered_buffer[: forward_batch.input_ids.shape[0]],
             hidden_states,
         )
+        if hidden_states.data_ptr() == global_hidden_states.data_ptr():
+            hidden_states = torch.empty_like(hidden_states)
         dp_scatter(hidden_states, global_hidden_states, forward_batch)
         return hidden_states, residual
 


### PR DESCRIPTION
This pull request introduces a small but important fix to the `_scatter_hidden_states` function in `python/sglang/srt/layers/communicator.py`. The change ensures that the `hidden_states` tensor is not inadvertently overwritten when its data pointer matches that of `global_hidden_states`, preventing potential in-place modification issues.

* Added a check to create a new tensor for `hidden_states` using `torch.empty_like` when it shares the same memory as `global_hidden_states`, ensuring safe scattering of hidden states.