### PR TITLE
Bug - Data corruption bug in DP communication

### DIFF
--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -541,6 +541,8 @@ class CommunicateSummableTensorPairFn:
             forward_batch.gathered_buffer[: forward_batch.input_ids.shape[0]],
             hidden_states,
         )
+        if hidden_states.data_ptr() == global_hidden_states.data_ptr():
+            hidden_states = torch.empty_like(hidden_states)
         dp_scatter(hidden_states, global_hidden_states, forward_batch)
         return hidden_states, residual
 


### PR DESCRIPTION
This pull request introduces a minor but important fix in the `_scatter_hidden_states` function within `python/sglang/srt/layers/communicator.py`. The change ensures that if `hidden_states` and `global_hidden_states` reference the same memory location, a new tensor is allocated to avoid potential memory overwrite issues.

* Memory safety improvement:
  * In `_scatter_hidden_states`, added a check to allocate a new tensor for `hidden_states` if it shares the same data pointer as `global_hidden_states`, preventing unintended in-place modification.