### PR TITLE
Append model deployment docs for three OSS models

### DIFF
--- a/scripts/ltp_scripts/models/GLM-5_deployment.md
+++ b/scripts/ltp_scripts/models/GLM-5_deployment.md
@@ -1,0 +1,91 @@
+# GLM-5 Deployment Guide (BF16, H100/H200)
+
+## Overview
+
+[GLM-5](https://huggingface.co/zai-org/GLM-5) is the most powerful model in the GLM series by Zhipu AI, with 744B total parameters (40B active). It is designed for complex systems engineering and long-horizon agentic tasks, achieving best-in-class performance among open-source models on reasoning, coding, and agentic benchmarks.
+
+This guide covers the **BF16 (full-precision)** deployment of GLM-5 on **NVIDIA H100 and H200** GPUs using SGLang.
+
+> **Note:** BF16 requires 2× the GPU count compared to FP8 ([zai-org/GLM-5-FP8](https://huggingface.co/zai-org/GLM-5-FP8)).
+>
+> | Hardware | BF16 TP Size | Nodes (8 GPUs each) |
+> |----------|-------------|---------------------|
+> | H200     | tp=16       | 2 nodes             |
+> | H100     | tp=32       | 4 nodes             |
+
+---
+
+## Docker Image
+
+Use the dedicated Hopper image for H100/H200:
+
+```bash
+docker pull lmsysorg/sglang:glm5-hopper
+```
+
+---
+
+## Deployment
+
+### Single Node
+
+For a single machine with sufficient GPUs (e.g., a 16-GPU H200 node or 32-GPU H100 node):
+
+**H200 (tp=16):**
+```bash
+python -m sglang.launch_server --model zai-org/GLM-5 --tp 16 --reasoning-parser glm45 --tool-call-parser glm47 --mem-fraction-static 0.85 --host 0.0.0.0 --port 30000
+```
+
+**H100 (tp=32):**
+```bash
+python -m sglang.launch_server --model zai-org/GLM-5 --tp 32 --reasoning-parser glm45 --tool-call-parser glm47 --mem-fraction-static 0.85 --host 0.0.0.0 --port 30000
+```
+
+### Multi-Node
+
+For clusters of 8-GPU nodes, run one command per node. Node 0 is the master and serves the API; worker nodes only participate in computation. Replace `<MASTER_IP>` with the IP of node 0.
+
+#### H200 — 2 Nodes × 8 GPUs (tp=16)
+
+**Node 0 (master):**
+```bash
+python -m sglang.launch_server --model zai-org/GLM-5 --tp 16 --nnodes 2 --node-rank 0 --dist-init-addr <MASTER_IP>:50000 --reasoning-parser glm45 --tool-call-parser glm47 --mem-fraction-static 0.85 --host 0.0.0.0 --port 30000
+```
+
+**Node 1:**
+```bash
+python -m sglang.launch_server --model zai-org/GLM-5 --tp 16 --nnodes 2 --node-rank 1 --dist-init-addr <MASTER_IP>:50000 --reasoning-parser glm45 --tool-call-parser glm47 --mem-fraction-static 0.85
+```
+
+#### H100 — 4 Nodes × 8 GPUs (tp=32)
+
+**Node 0 (master):**
+```bash
+python -m sglang.launch_server --model zai-org/GLM-5 --tp 32 --nnodes 4 --node-rank 0 --dist-init-addr <MASTER_IP>:50000 --reasoning-parser glm45 --tool-call-parser glm47 --mem-fraction-static 0.85 --host 0.0.0.0 --port 30000
+```
+
+**Nodes 1–3** (set `--node-rank` to 1, 2, or 3 on each):
+```bash
+python -m sglang.launch_server --model zai-org/GLM-5 --tp 32 --nnodes 4 --node-rank <N> --dist-init-addr <MASTER_IP>:50000 --reasoning-parser glm45 --tool-call-parser glm47 --mem-fraction-static 0.85
+```
+
+---
+
+## Key Launch Arguments
+
+| Argument | Description |
+|---|---|
+| `--tp` | Tensor parallelism size (total GPUs across all nodes) |
+| `--nnodes` | Number of nodes |
+| `--node-rank` | Rank of the current node (0 = master) |
+| `--dist-init-addr` | `<master_ip>:<port>` for distributed coordination |
+| `--reasoning-parser glm45` | Enables structured extraction of thinking/reasoning content |
+| `--tool-call-parser glm47` | Enables tool/function call parsing |
+| `--mem-fraction-static 0.85` | Fraction of GPU memory reserved for static weights |
+
+---
+
+## References
+
+- [SGLang GLM-5 Cookbook](https://cookbook.sglang.io/autoregressive/GLM/GLM-5)
+- [GLM-5 on HuggingFace](https://huggingface.co/zai-org/GLM-5)

--- a/scripts/ltp_scripts/models/Kimi-K2.5_deployment.md
+++ b/scripts/ltp_scripts/models/Kimi-K2.5_deployment.md
@@ -1,0 +1,84 @@
+# Kimi-K2.5 Deployment Guide (BF16, H200)
+
+## Overview
+
+[Kimi-K2.5](https://huggingface.co/moonshotai/Kimi-K2.5) is an open-source native multimodal agentic model by Moonshot AI, built through continual pretraining on approximately 15 trillion mixed visual and text tokens. It integrates vision and language understanding with advanced agentic capabilities, supporting both thinking (reasoning) and instant modes.
+
+This guide covers the **BF16 (full-precision)** deployment of Kimi-K2.5 on **NVIDIA H200** GPUs using SGLang.
+
+> **Note:** Kimi-K2.5 requires GPUs with ≥140GB memory each. **H100 (80GB/94GB) is not supported.** H200 (141GB) is the minimum supported NVIDIA GPU. Requires SGLang **≥ 0.5.9**.
+>
+> | Hardware | BF16 TP Size |
+> |----------|-------------|
+> | H200     | tp=8        |
+
+---
+
+## Docker Image
+
+Use the standard SGLang image for NVIDIA Hopper GPUs:
+
+```bash
+docker pull lmsysorg/sglang:v0.5.9-cu124
+```
+
+---
+
+## Deployment
+
+### Single Node
+
+For a single 8-GPU H200 node (tp=8):
+
+```bash
+python -m sglang.launch_server --model moonshotai/Kimi-K2.5 --tp 8 --trust-remote-code --reasoning-parser kimi_k2 --tool-call-parser kimi_k2 --host 0.0.0.0 --port 30000
+```
+
+### Multi-Node
+
+If your cluster only has 8-GPU nodes and you want to serve multiple requests at higher throughput across nodes, or if your workload warrants a larger TP degree, you can span across nodes. Replace `<MASTER_IP>` with the IP of node 0.
+
+#### H200 — 2 Nodes × 8 GPUs (tp=16)
+
+**Node 0 (master):**
+```bash
+python -m sglang.launch_server --model moonshotai/Kimi-K2.5 --tp 16 --nnodes 2 --node-rank 0 --dist-init-addr <MASTER_IP>:50000 --trust-remote-code --reasoning-parser kimi_k2 --tool-call-parser kimi_k2 --host 0.0.0.0 --port 30000
+```
+
+**Node 1:**
+```bash
+python -m sglang.launch_server --model moonshotai/Kimi-K2.5 --tp 16 --nnodes 2 --node-rank 1 --dist-init-addr <MASTER_IP>:50000 --trust-remote-code --reasoning-parser kimi_k2 --tool-call-parser kimi_k2
+```
+
+#### H200 — 4 Nodes × 8 GPUs (tp=32)
+
+**Node 0 (master):**
+```bash
+python -m sglang.launch_server --model moonshotai/Kimi-K2.5 --tp 32 --nnodes 4 --node-rank 0 --dist-init-addr <MASTER_IP>:50000 --trust-remote-code --reasoning-parser kimi_k2 --tool-call-parser kimi_k2 --host 0.0.0.0 --port 30000
+```
+
+**Nodes 1–3** (set `--node-rank` to 1, 2, or 3 on each):
+```bash
+python -m sglang.launch_server --model moonshotai/Kimi-K2.5 --tp 32 --nnodes 4 --node-rank <N> --dist-init-addr <MASTER_IP>:50000 --trust-remote-code --reasoning-parser kimi_k2 --tool-call-parser kimi_k2
+```
+
+---
+
+## Key Launch Arguments
+
+| Argument | Description |
+|---|---|
+| `--tp` | Tensor parallelism size (total GPUs across all nodes) |
+| `--trust-remote-code` | Required for the `kimi_k2.5` model architecture |
+| `--nnodes` | Number of nodes (multi-node only) |
+| `--node-rank` | Rank of the current node, 0 = master (multi-node only) |
+| `--dist-init-addr` | `<master_ip>:<port>` for distributed coordination (multi-node only) |
+| `--reasoning-parser kimi_k2` | Enables structured extraction of thinking/reasoning content |
+| `--tool-call-parser kimi_k2` | Enables tool/function call parsing |
+
+---
+
+## References
+
+- [SGLang Kimi-K2.5 Cookbook](https://cookbook.sglang.io/autoregressive/Moonshotai/Kimi-K2.5)
+- [Kimi-K2.5 on HuggingFace](https://huggingface.co/moonshotai/Kimi-K2.5)

--- a/scripts/ltp_scripts/models/MiniMax-M2.5_deployment.md
+++ b/scripts/ltp_scripts/models/MiniMax-M2.5_deployment.md
@@ -1,0 +1,93 @@
+# MiniMax-M2.5 Deployment Guide (BF16, H100/H200)
+
+## Overview
+
+[MiniMax-M2.5](https://huggingface.co/MiniMaxAI/MiniMax-M2.5) is a powerful MoE language model developed by MiniMax, built for real-world productivity with state-of-the-art performance across coding, reasoning, agentic tasks, and tool use. It achieves strong results on SWE-bench, AIME25, BrowseComp, and Terminal Bench 2.
+
+This guide covers the **BF16 (full-precision)** deployment of MiniMax-M2.5 on **NVIDIA H100 and H200** GPUs using SGLang.
+
+> **Note:** MiniMax-M2.5 supports both 4-GPU and 8-GPU single-node deployment on H100 and H200. Requires SGLang **≥ 0.5.9**.
+>
+> | Hardware | TP Size | EP Size | Min GPUs |
+> |----------|---------|---------|----------|
+> | H100 / H200 | tp=4  | ep=4  | 4        |
+> | H100 / H200 | tp=8  | ep=8  | 8        |
+
+---
+
+## Docker Image
+
+Use the standard SGLang image:
+
+```bash
+docker pull lmsysorg/sglang:v0.5.9-cu124
+```
+
+---
+
+## Deployment
+
+### Single Node
+
+#### 4-GPU (tp=4)
+
+```bash
+python -m sglang.launch_server --model MiniMaxAI/MiniMax-M2.5 --tp 4 --ep 4 --trust-remote-code --reasoning-parser minimax-append-think --tool-call-parser minimax-m2 --mem-fraction-static 0.85 --host 0.0.0.0 --port 30000
+```
+
+#### 8-GPU (tp=8)
+
+```bash
+python -m sglang.launch_server --model MiniMaxAI/MiniMax-M2.5 --tp 8 --ep 8 --trust-remote-code --reasoning-parser minimax-append-think --tool-call-parser minimax-m2 --mem-fraction-static 0.85 --host 0.0.0.0 --port 30000
+```
+
+### Multi-Node
+
+For clusters of 8-GPU nodes, run one command per node. Node 0 is the master and serves the API; worker nodes only participate in computation. Replace `<MASTER_IP>` with the IP of node 0.
+
+#### 2 Nodes × 8 GPUs (tp=16, ep=16)
+
+**Node 0 (master):**
+```bash
+python -m sglang.launch_server --model MiniMaxAI/MiniMax-M2.5 --tp 16 --ep 16 --nnodes 2 --node-rank 0 --dist-init-addr <MASTER_IP>:50000 --trust-remote-code --reasoning-parser minimax-append-think --tool-call-parser minimax-m2 --mem-fraction-static 0.85 --host 0.0.0.0 --port 30000
+```
+
+**Node 1:**
+```bash
+python -m sglang.launch_server --model MiniMaxAI/MiniMax-M2.5 --tp 16 --ep 16 --nnodes 2 --node-rank 1 --dist-init-addr <MASTER_IP>:50000 --trust-remote-code --reasoning-parser minimax-append-think --tool-call-parser minimax-m2 --mem-fraction-static 0.85
+```
+
+#### 4 Nodes × 8 GPUs (tp=32, ep=32)
+
+**Node 0 (master):**
+```bash
+python -m sglang.launch_server --model MiniMaxAI/MiniMax-M2.5 --tp 32 --ep 32 --nnodes 4 --node-rank 0 --dist-init-addr <MASTER_IP>:50000 --trust-remote-code --reasoning-parser minimax-append-think --tool-call-parser minimax-m2 --mem-fraction-static 0.85 --host 0.0.0.0 --port 30000
+```
+
+**Nodes 1–3** (set `--node-rank` to 1, 2, or 3 on each):
+```bash
+python -m sglang.launch_server --model MiniMaxAI/MiniMax-M2.5 --tp 32 --ep 32 --nnodes 4 --node-rank <N> --dist-init-addr <MASTER_IP>:50000 --trust-remote-code --reasoning-parser minimax-append-think --tool-call-parser minimax-m2 --mem-fraction-static 0.85
+```
+
+---
+
+## Key Launch Arguments
+
+| Argument | Description |
+|---|---|
+| `--tp` | Tensor parallelism size (total GPUs across all nodes) |
+| `--ep` | Expert parallelism size; set equal to `--tp` for MoE models |
+| `--trust-remote-code` | Required for MiniMax model loading |
+| `--reasoning-parser minimax-append-think` | Separates `<think>...</think>` content from the response |
+| `--tool-call-parser minimax-m2` | Enables tool/function call parsing |
+| `--mem-fraction-static 0.85` | Fraction of GPU memory reserved for static weights |
+| `--nnodes` | Number of nodes (multi-node only) |
+| `--node-rank` | Rank of the current node, 0 = master (multi-node only) |
+| `--dist-init-addr` | `<master_ip>:<port>` for distributed coordination (multi-node only) |
+
+---
+
+## References
+
+- [SGLang MiniMax-M2.5 Cookbook](https://cookbook.sglang.io/autoregressive/MiniMax/MiniMax-M2.5)
+- [MiniMax-M2.5 on HuggingFace](https://huggingface.co/MiniMaxAI/MiniMax-M2.5)


### PR DESCRIPTION
This pull request adds comprehensive deployment guides for three large open-source language models—GLM-5, Kimi-K2.5, and MiniMax-M2.5—on NVIDIA H100 and H200 GPUs, using SGLang. Each guide provides detailed instructions for both single-node and multi-node (distributed) deployments, including required hardware, Docker images, launch arguments, and references to further documentation.

Deployment documentation for new models:

* Added `GLM-5_deployment.md` with step-by-step instructions for deploying GLM-5 in BF16 precision on H100/H200 GPUs, covering both single-node and multi-node setups, hardware requirements, launch commands, and key arguments.
* Added `Kimi-K2.5_deployment.md` detailing deployment of the Kimi-K2.5 multimodal model on H200 GPUs, including hardware prerequisites, Docker image, launch commands for various cluster sizes, and explanation of required arguments.
* Added `MiniMax-M2.5_deployment.md` with instructions for deploying MiniMax-M2.5 on H100/H200 GPUs, supporting both 4-GPU and 8-GPU nodes, as well as multi-node clusters, including MoE-specific parameters (`--ep`), and launch argument explanations.